### PR TITLE
Changed status badge to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 gdp is a CLI tool for pushing the tag associated with deployment and publishing the release note in GitHub.
 
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/Connehito/gdp)
-[![Build Status](https://travis-ci.org/Connehito/gdp.svg?branch=master)](https://travis-ci.org/Connehito/gdp)
+[![CI](https://github.com/Connehito/gdp/actions/workflows/ci.yml/badge.svg)](https://github.com/Connehito/gdp/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Connehito/gdp)](https://goreportcard.com/report/github.com/Connehito/gdp)
 [![GoDoc](https://godoc.org/github.com/Connehito/gdp?status.svg)](https://godoc.org/github.com/Connehito/gdp)
 [![Latest Version](http://img.shields.io/github/release/Connehito/gdp.svg?style=flat-square)](https://github.com/Connehito/gdp/releases/latest)


### PR DESCRIPTION
Changed status badge from Travis CI to GitHub Actions.
<img width="261" alt="image" src="https://user-images.githubusercontent.com/2541034/178164620-22459458-429f-47f4-8069-c221a98052cd.png">

see https://docs.github.com/ja/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge